### PR TITLE
Revert "Bump pre-commit from 3.3.3 to 3.7.0"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 mypy == 1.10.0
-pre-commit == 3.7.0
+pre-commit == 3.3.3
 pylint == 3.1.0
 pytest == 8.2.0
 pytest-asyncio == 0.23.6


### PR DESCRIPTION
Reverts TotallyNotRobots/bnc-bot#7

This version is incompatible with python 3.8