### PR TITLE
Add configurable BNC network name and client-facing ports

### DIFF
--- a/bncbot/bot.py
+++ b/bncbot/bot.py
@@ -309,8 +309,8 @@ async def cmd_resetpass(
     event.message(f"BNC password reset for {nick}")
     event.message(
         f"SEND {nick} [New Password!] Your BNC auth is Username: {nick} "
-        f"Password: {passwd} (Ports: 5457 for SSL - 5456 for NON-SSL) "
-        f"Help: /server bnc.snoonet.org 5456 and /PASS {nick}:{passwd}",
+        f"Password: {passwd} {conn.client_connect_info()} and /PASS "
+        f"{nick}:{passwd}",
         "MemoServ",
     )
 

--- a/bncbot/config.py
+++ b/bncbot/config.py
@@ -30,6 +30,9 @@ class BotConfig(FileBasedDataModel):
     server: str = "bnc.snoonet.org"
     port: int = 5457
     ssl: bool = True
+    bnc_network: str = "Snoonet"
+    client_ssl_port: int = 5457
+    client_non_ssl_port: int = 5456
     admins: list[str] = ["*!*@snoonet/staff/*", "*!*@snoonet/manager/*"]
     log_channel: str = "##log_channel"
     command_prefix: str = "."

--- a/bncbot/conn.py
+++ b/bncbot/conn.py
@@ -254,6 +254,14 @@ class Conn:
 
         return True
 
+    def client_connect_info(self) -> str:
+        return (
+            f"(Ports: {self.config.client_ssl_port} for SSL - "
+            f"{self.config.client_non_ssl_port} for NON-SSL) "
+            f"Help: /server {self.config.server} "
+            f"{self.config.client_non_ssl_port}"
+        )
+
     def is_admin(self, mask: str) -> bool:
         return any(fnmatch(mask.lower(), pat.lower()) for pat in self.admins)
 
@@ -304,12 +312,14 @@ class Conn:
         self.module_msg("controlpanel", f"Set Ident {username} {nick}")
         self.module_msg("controlpanel", f"Set Realname {username} {nick}")
         self.send("znc saveconfig")
-        self.module_msg("controlpanel", f"reconnect {username} Snoonet")
+        self.module_msg(
+            "controlpanel", f"reconnect {username} {self.config.bnc_network}"
+        )
         self.msg(
             "MemoServ",
             f"SEND {nick} Your BNC auth is Username: {username} Password: "
-            f"{passwd} (Ports: 5457 for SSL - 5456 for NON-SSL) Help: "
-            f"/server bnc.snoonet.org 5456 and /PASS {username}:{passwd}",
+            f"{passwd} {self.client_connect_info()} and /PASS "
+            f"{username}:{passwd}",
         )
         self.bnc_users[username] = host
         self.save_data()

--- a/config.default.json
+++ b/config.default.json
@@ -5,6 +5,9 @@
     "server": "bnc.snoonet.org",
     "port": 5457,
     "ssl": true,
+    "bnc_network": "Snoonet",
+    "client_ssl_port": 5457,
+    "client_non_ssl_port": 5456,
     "admins": [
         "*!*@snoonet/staff/*",
         "*!*@snoonet/manager/*",

--- a/tests/conn_test.py
+++ b/tests/conn_test.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2019 Snoonet
+# SPDX-FileCopyrightText: 2020-present linuxdaemon <linuxdaemon.irc@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+from unittest import mock
+
+from bncbot.config import BNCData, BotConfig
+from bncbot.conn import Conn
+
+
+def _make_conn(config: BotConfig, run_dir: Path = Path()) -> Conn:
+    conn = Conn.__new__(Conn)
+    conn.config = config
+    conn.run_dir = run_dir
+    conn.bnc_data = BNCData()
+    return conn
+
+
+def test_client_connect_info_defaults() -> None:
+    conn = _make_conn(BotConfig())
+    assert conn.client_connect_info() == (
+        "(Ports: 5457 for SSL - 5456 for NON-SSL) "
+        "Help: /server bnc.snoonet.org 5456"
+    )
+
+
+def test_client_connect_info_custom_config() -> None:
+    conn = _make_conn(
+        BotConfig(
+            server="bnc.example.org",
+            client_ssl_port=6697,
+            client_non_ssl_port=6667,
+        )
+    )
+    assert conn.client_connect_info() == (
+        "(Ports: 6697 for SSL - 6667 for NON-SSL) "
+        "Help: /server bnc.example.org 6667"
+    )
+
+
+def test_add_user_reconnects_to_configured_network(tmp_path: Path) -> None:
+    conn = _make_conn(BotConfig(bnc_network="MyNetwork"), run_dir=tmp_path)
+
+    with mock.patch.object(conn, "send") as mock_send:
+        assert conn.add_user("somenick") is True
+
+    reconnect_cmds = [
+        call.args[0]
+        for call in mock_send.call_args_list
+        if "reconnect somenick" in call.args[0]
+    ]
+    assert reconnect_cmds == [
+        "PRIVMSG *controlpanel :reconnect somenick MyNetwork"
+    ]
+    assert conn.bnc_users["somenick"] is not None


### PR DESCRIPTION
The reconnect network and the SSL/non-SSL ports advertised to users in their BNC connection info memo were hardcoded to Snoonet-specific values. These are now configurable via bnc_network, client_ssl_port, and client_non_ssl_port, defaulting to the previous hardcoded values.